### PR TITLE
increase message size for utf messages

### DIFF
--- a/lib/pushmeup/apns/notification.rb
+++ b/lib/pushmeup/apns/notification.rb
@@ -32,7 +32,7 @@ module APNS
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
       aps.merge!(self.other) if self.other
-      aps.to_json
+      aps.to_json.gsub(/\\u([\da-fA-F]{4})/) {|m| [$1].pack("H*").unpack("n*").pack("U*")}
     end
     
   end


### PR DESCRIPTION
as `to_json` escapes unicode characters max message length for utf messages is six times less than ascii. i've applied `unescape_unicode` to packed message taken from this post: this post: http://stackoverflow.com/questions/9230663/ruby-unescape-unicode-string 
