### PR TITLE
Allow users to set their own GCM host (e.g. for testing)

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -6,7 +6,7 @@
 # First we specify our desired <ruby>[@<gemset>], the @gemset name is optional,
 # Only full ruby name is supported here, for short names use:
 #     echo "rvm use 1.9.3" > .rvmrc
-environment_id="ruby-1.9.3-p125@pushmeup"
+environment_id="ruby-1.9.3@pushmeup"
 
 # Uncomment the following lines if you want to verify rvm version per project
 # rvmrc_rvm_version="1.11.5 (master)" # 1.10.1 seams as a safe start

--- a/lib/pushmeup/gcm/core.rb
+++ b/lib/pushmeup/gcm/core.rb
@@ -4,14 +4,14 @@ require 'json'
 
 module GCM
   include HTTParty
-  
+
   @host = 'https://android.googleapis.com/gcm/send'
   @format = :json
   @key = nil
 
   class << self
     attr_accessor :host, :format, :key
-    
+
     def key(identity = nil)
       if @key.is_a?(Hash)
         raise %{If your key is a hash of keys you'l need to pass a identifier to the notification!} if identity.nil?
@@ -20,7 +20,7 @@ module GCM
         return @key
       end
     end
-    
+
     def key_identities
       if @key.is_a?(Hash)
         return @key.keys
@@ -29,12 +29,12 @@ module GCM
       end
     end
   end
-  
+
   def self.send_notification(device_tokens, data = {}, options = {})
     n = GCM::Notification.new(device_tokens, data, options)
     self.send_notifications([n])
   end
-  
+
   def self.send_notifications(notifications)
     responses = []
     notifications.each do |n|
@@ -44,7 +44,7 @@ module GCM
   end
 
   private
-  
+
   def self.prepare_and_send(n)
     if n.device_tokens.count < 1 || n.device_tokens.count > 1000
       raise "Number of device_tokens invalid, keep it betwen 1 and 1000"
@@ -55,7 +55,7 @@ module GCM
     if @key.is_a?(Hash) && n.identity.nil?
       raise %{If your key is a hash of keys you'l need to pass a identifier to the notification!}
     end
-    
+
     if self.format == :json
       self.send_push_as_json(n)
     elsif self.format == :text
@@ -64,7 +64,7 @@ module GCM
       raise "Invalid format"
     end
   end
-  
+
   def self.send_push_as_json(n)
     headers = {
       'Authorization' => "key=#{ self.key(n.identity) }",
@@ -79,7 +79,7 @@ module GCM
     }
     return self.send_to_server(headers, body.to_json)
   end
-  
+
   def self.send_push_as_plain_text(n)
     raise "Still has to be done: http://developer.android.com/guide/google/gcm/gcm.html"
     headers = {
@@ -89,13 +89,13 @@ module GCM
     }
     return self.send_to_server(headers, body)
   end
-  
+
   def self.send_to_server(headers, body)
     params = {:headers => headers, :body => body}
-    response = self.post('https://android.googleapis.com/gcm/send', params)
+    response = self.post(self.host, params)
     return build_response(response)
   end
-  
+
   def self.build_response(response)
     case response.code
       when 200
@@ -110,5 +110,5 @@ module GCM
         {:response => 'Server is temporarily unavailable.', :status_code => response.code}
     end
   end
-  
+
 end


### PR DESCRIPTION
1. Allow for any 1.9.3 in the rvmrc
2. Allow users to set their own GCM host as advertised
