### PR TITLE
Configure certificate from any object that responds to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Currently we have only support for ``iOS`` and ``Android`` but we are planning c
 ## Installation
 
     $ gem install pushmeup
-    
+
 or add to your ``Gemfile``
 
     gem 'pushmeup'
-    
+
 and install it with
 
     $ bundle install
@@ -40,13 +40,13 @@ and install it with
 
 3. After you have created your ``pem`` file. Set the host, port and certificate file location on the APNS class. You just need to set this once:
 
-        APNS.host = 'gateway.push.apple.com' 
+        APNS.host = 'gateway.push.apple.com'
         # gateway.sandbox.push.apple.com is default
-        
-        APNS.port = 2195 
+
+        APNS.port = 2195
         # this is also the default. Shouldn't ever have to set this, but just in case Apple goes crazy, you can.
 
-        APNS.pem  = '/path/to/pem/file'
+        APNS.pem_data  = "your cert-pem content string"
         # this is the file you just created
 
         APNS.pass = ''
@@ -69,9 +69,9 @@ and install it with
 
 #### Sending more information along
 
-        APNS.send_notification(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default', 
+        APNS.send_notification(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default',
                                             :other => {:sent => 'with apns gem', :custom_param => "value"})
-                                            
+
 this will result in a payload like this:
 
         {"aps":{"alert":"Hello iPhone!","badge":1,"sound":"default"},"sent":"with apns gem", "custom_param":"value"}
@@ -81,13 +81,13 @@ this will result in a payload like this:
     - (void)applicationDidFinishLaunching:(UIApplication *)application {
         // Register with apple that this app will use push notification
         ...
-        
+
         [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeBadge)];
-        
+
         ...
-        
+
     }
-    
+
     - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
         // Show the device token obtained from apple to the log
         NSLog("deviceToken: %", deviceToken);
@@ -105,7 +105,7 @@ this will result in a payload like this:
 
 		GCM.key = "123abc456def"
 		# this is the apiKey obtained from here https://code.google.com/apis/console/
-		
+
 ### Usage
 
 #### Sending a single notification:
@@ -136,17 +136,17 @@ for more information on parameters check documentation: [GCM | Android Developer
 
 		data1 = {:key => "value", :key2 => ["array", "value"]}
 		# must be an hash with all values you want inside you notification
-		
+
 		options1 = {:collapse_key => "placar_score_global", :time_to_live => 3600, :delay_while_idle => false}
 		# options for the notification
-		
+
 		n1 = GCM::Notification.new(destination1, data1, options1)
 		n2 = GCM::Notification.new(destination2, data2)
 		n3 = GCM::Notification.new(destination3, data3, options2)
 
 		GCM.send_notifications( [n1, n2, n3] )
 		# In this case, every notification has his own parameters
-	
+
 for more information on parameters check documentation: [GCM | Android Developers](http://developer.android.com/guide/google/gcm/gcm.html#request)
 
 #### Getting your Android device token (regId)
@@ -155,7 +155,7 @@ Check this link [GCM: Getting Started](http://developer.android.com/guide/google
 
 ### (Optional) You can add multiple keys for GCM
 
-You can use multiple keys to send notifications, to do it just do this changes in the code 
+You can use multiple keys to send notifications, to do it just do this changes in the code
 
 #### Configure
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Currently we have only support for ``iOS`` and ``Android`` but we are planning c
 ## Installation
 
     $ gem install pushmeup
-
+    
 or add to your ``Gemfile``
 
     gem 'pushmeup'
-
+    
 and install it with
 
     $ bundle install
@@ -40,13 +40,13 @@ and install it with
 
 3. After you have created your ``pem`` file. Set the host, port and certificate file location on the APNS class. You just need to set this once:
 
-        APNS.host = 'gateway.push.apple.com'
+        APNS.host = 'gateway.push.apple.com' 
         # gateway.sandbox.push.apple.com is default
-
-        APNS.port = 2195
+        
+        APNS.port = 2195 
         # this is also the default. Shouldn't ever have to set this, but just in case Apple goes crazy, you can.
 
-        APNS.pem_data  = "your cert-pem content string"
+        APNS.pem  = '/path/to/pem/file'
         # this is the file you just created
 
         APNS.pass = ''
@@ -69,9 +69,9 @@ and install it with
 
 #### Sending more information along
 
-        APNS.send_notification(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default',
+        APNS.send_notification(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default', 
                                             :other => {:sent => 'with apns gem', :custom_param => "value"})
-
+                                            
 this will result in a payload like this:
 
         {"aps":{"alert":"Hello iPhone!","badge":1,"sound":"default"},"sent":"with apns gem", "custom_param":"value"}
@@ -81,13 +81,13 @@ this will result in a payload like this:
     - (void)applicationDidFinishLaunching:(UIApplication *)application {
         // Register with apple that this app will use push notification
         ...
-
+        
         [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeBadge)];
-
+        
         ...
-
+        
     }
-
+    
     - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
         // Show the device token obtained from apple to the log
         NSLog("deviceToken: %", deviceToken);
@@ -105,7 +105,7 @@ this will result in a payload like this:
 
 		GCM.key = "123abc456def"
 		# this is the apiKey obtained from here https://code.google.com/apis/console/
-
+		
 ### Usage
 
 #### Sending a single notification:
@@ -136,17 +136,17 @@ for more information on parameters check documentation: [GCM | Android Developer
 
 		data1 = {:key => "value", :key2 => ["array", "value"]}
 		# must be an hash with all values you want inside you notification
-
+		
 		options1 = {:collapse_key => "placar_score_global", :time_to_live => 3600, :delay_while_idle => false}
 		# options for the notification
-
+		
 		n1 = GCM::Notification.new(destination1, data1, options1)
 		n2 = GCM::Notification.new(destination2, data2)
 		n3 = GCM::Notification.new(destination3, data3, options2)
 
 		GCM.send_notifications( [n1, n2, n3] )
 		# In this case, every notification has his own parameters
-
+	
 for more information on parameters check documentation: [GCM | Android Developers](http://developer.android.com/guide/google/gcm/gcm.html#request)
 
 #### Getting your Android device token (regId)
@@ -155,7 +155,7 @@ Check this link [GCM: Getting Started](http://developer.android.com/guide/google
 
 ### (Optional) You can add multiple keys for GCM
 
-You can use multiple keys to send notifications, to do it just do this changes in the code
+You can use multiple keys to send notifications, to do it just do this changes in the code 
 
 #### Configure
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ and install it with
         APNS.pass = ''
         # Just in case your pem need a password
 
+   Alternatively, If you don't have the certificate stored in a file, you can pass any object that responds to ``read``. 
+
+        APNS.pem = StringIO.new(pem_string)
+
 ### Usage
 
 #### Sending a single notification:

--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -7,31 +7,29 @@ module APNS
   @host = 'gateway.sandbox.push.apple.com'
   @port = 2195
   # openssl pkcs12 -in mycert.p12 -out client-cert.pem -nodes -clcerts
-  @pem_data = nil
-  # this should the content of the pem-cert(String format)
-  # changed this because all certs are stored in database
+  @pem = nil # this should be the path of the pem file not the contentes
   @pass = nil
-
+  
   class << self
-    attr_accessor :host, :pem_data, :port, :pass
+    attr_accessor :host, :pem, :port, :pass
   end
-
+  
   def self.send_notification(device_token, message)
     n = APNS::Notification.new(device_token, message)
     self.send_notifications([n])
   end
-
+  
   def self.send_notifications(notifications)
     sock, ssl = self.open_connection
-
+    
     notifications.each do |n|
-      ssl.write(n.packaged_notification)
-    end
+        ssl.write(n.packaged_notification)
+      end
 
     ssl.close
     sock.close
   end
-
+  
   def self.feedback
     sock, ssl = self.feedback_connection
 
@@ -49,34 +47,43 @@ module APNS
     return apns_feedback
   end
 
-protected
-  def self.build_connection_context
-    raise "Your don't have valid pem data. (APNS.pem = Certificate.development_pem)" unless pem_data
-    context      = OpenSSL::SSL::SSLContext.new
-    context.cert = OpenSSL::X509::Certificate.new(self.pem_data)
-    context.key  = OpenSSL::PKey::RSA.new(self.pem_data, self.pass)
-    context
+  protected
+
+  def self.pem_data
+    raise "Your pem file is not set. (APNS.pem = /path/to/cert.pem or object that responds to read)" unless pem
+    if pem.respond_to? :read
+      self.pem.read
+    else
+      raise "The path to your pem file does not exist!" unless File.exist?(@pem)
+      File.read(self.pem)
+    end
   end
 
   def self.open_connection
-    context = self.build_connection_context
-    sock    = TCPSocket.new(self.host, self.port)
-    ssl     = OpenSSL::SSL::SSLSocket.new(sock,context)
+    context      = OpenSSL::SSL::SSLContext.new
+    context.cert = OpenSSL::X509::Certificate.new(self.pem_data)
+    context.key  = OpenSSL::PKey::RSA.new(self.pem_data, self.pass)
+
+    sock         = TCPSocket.new(self.host, self.port)
+    ssl          = OpenSSL::SSL::SSLSocket.new(sock,context)
     ssl.connect
 
     return sock, ssl
   end
-
+  
   def self.feedback_connection
-    context = self.build_connection_context
+    context      = OpenSSL::SSL::SSLContext.new
+    context.cert = OpenSSL::X509::Certificate.new(self.pem_data)
+    context.key  = OpenSSL::PKey::RSA.new(self.pem_data, self.pass)
+    
     fhost = self.host.gsub('gateway','feedback')
     puts fhost
-
+    
     sock         = TCPSocket.new(fhost, 2196)
     ssl          = OpenSSL::SSL::SSLSocket.new(sock, context)
     ssl.connect
 
     return sock, ssl
   end
-
+  
 end

--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -46,16 +46,23 @@ module APNS
 
     return apns_feedback
   end
-  
+
   protected
 
+  def self.pem_data
+    raise "Your pem file is not set. (APNS.pem = /path/to/cert.pem or object that responds to read)" unless pem
+    if pem.respond_to? :read
+      self.pem.read
+    else
+      raise "The path to your pem file does not exist!" unless File.exist?(@pem)
+      File.read(self.pem)
+    end
+  end
+
   def self.open_connection
-    raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
-    raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
-    
     context      = OpenSSL::SSL::SSLContext.new
-    context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
-    context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
+    context.cert = OpenSSL::X509::Certificate.new(self.pem_data)
+    context.key  = OpenSSL::PKey::RSA.new(self.pem_data, self.pass)
 
     sock         = TCPSocket.new(self.host, self.port)
     ssl          = OpenSSL::SSL::SSLSocket.new(sock,context)
@@ -65,12 +72,9 @@ module APNS
   end
   
   def self.feedback_connection
-    raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
-    raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
-    
     context      = OpenSSL::SSL::SSLContext.new
-    context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
-    context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
+    context.cert = OpenSSL::X509::Certificate.new(self.pem_data)
+    context.key  = OpenSSL::PKey::RSA.new(self.pem_data, self.pass)
     
     fhost = self.host.gsub('gateway','feedback')
     puts fhost

--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -52,11 +52,13 @@ module APNS
   def self.pem_data
     raise "Your pem file is not set. (APNS.pem = /path/to/cert.pem or object that responds to read)" unless pem
     if pem.respond_to? :read
-      self.pem.read
+      data = pem.read
+      pem.rewind if pem.respond_to(:rewind)
     else
-      raise "The path to your pem file does not exist!" unless File.exist?(@pem)
-      File.read(self.pem)
+      raise "The path to your pem file does not exist!" unless File.exist?(pem)
+      data = File.read(pem)
     end
+    data
   end
 
   def self.open_connection

--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -53,7 +53,7 @@ module APNS
     raise "Your pem file is not set. (APNS.pem = /path/to/cert.pem or object that responds to read)" unless pem
     if pem.respond_to? :read
       data = pem.read
-      pem.rewind if pem.respond_to(:rewind)
+      pem.rewind if pem.respond_to?(:rewind)
     else
       raise "The path to your pem file does not exist!" unless File.exist?(pem)
       data = File.read(pem)


### PR DESCRIPTION
We have certificates that reside in a database. This change allows certificates to be configured from a file path or any object that responds to `read`.
