### PR TITLE
Added content-available to ios parameters

### DIFF
--- a/lib/pushmeup/apns/notification.rb
+++ b/lib/pushmeup/apns/notification.rb
@@ -1,6 +1,6 @@
 module APNS
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other
+    attr_accessor :device_token, :alert, :badge, :sound, :content_available, :other
 
     def initialize(device_token, message)
       self.device_token = device_token
@@ -8,6 +8,7 @@ module APNS
         self.alert = message[:alert]
         self.badge = message[:badge]
         self.sound = message[:sound]
+        self.content_available = message[:content_available]
         self.other = message[:other]
       elsif message.is_a?(String)
         self.alert = message
@@ -31,6 +32,7 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['content-available'] = self.content_available if self.content_available
       aps.merge!(self.other) if self.other
       aps.to_json.gsub(/\\u([\da-fA-F]{4})/) {|m| [$1].pack("H*").unpack("n*").pack("U*")}
     end
@@ -40,6 +42,7 @@ module APNS
       alert == that.alert &&
       badge == that.badge &&
       sound == that.sound &&
+      content_available == that.content_available &&
       other == that.other
     end
 


### PR DESCRIPTION
According to the ios documentation, the parameter content-available was not being sent.
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
