### PR TITLE
Check string keys in APNS::Notifications message hash

### DIFF
--- a/lib/pushmeup/apns/notification.rb
+++ b/lib/pushmeup/apns/notification.rb
@@ -5,10 +5,10 @@ module APNS
     def initialize(device_token, message)
       self.device_token = device_token
       if message.is_a?(Hash)
-        self.alert = message[:alert]
-        self.badge = message[:badge]
-        self.sound = message[:sound]
-        self.other = message[:other]
+        self.alert = message[:alert] || message['alert']
+        self.badge = message[:badge] || message['badge']
+        self.sound = message[:sound] || message['sound']
+        self.other = message[:other] || message['other']
       elsif message.is_a?(String)
         self.alert = message
       else


### PR DESCRIPTION
When queuing a message through Redis (Sidekiq in my case), hash parameters are serialized and unserialized via JSON dump/load, so any symbol keys are converted to strings. Since APNS::Notification only checks symbol keys, the push will fail unless you symbolize the keys again after the body is given to the Sidekiq worker.

This PR will check for string keys in addition to symbol keys so that this situation can be avoided.
