### PR TITLE
Added silent Apple push notifications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ and install it with
     
     # Send single notifications
     APNS.send_notification(device_token, 'Hello iPhone!' )
-    APNS.send_notification(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default')
+    APNS.send_notification(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default', :silent => 1)
     
     # Send multiple notifications
     n1 = APNS::Notification.new(device_token, 'Hello iPhone!' )
-    n2 = APNS::Notification.new(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default')
+    n2 = APNS::Notification.new(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default', :silent => 0)
     APNS.send_notifications([n1, n2])
     
     ...

--- a/lib/pushmeup/apns/notification.rb
+++ b/lib/pushmeup/apns/notification.rb
@@ -1,6 +1,6 @@
 module APNS
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other
+    attr_accessor :device_token, :alert, :badge, :sound, :silent, :other
 
     def initialize(device_token, message)
       self.device_token = device_token
@@ -9,6 +9,7 @@ module APNS
         self.badge = message[:badge]
         self.sound = message[:sound]
         self.other = message[:other]
+        self.silent = message[:silent]
       elsif message.is_a?(String)
         self.alert = message
       else
@@ -31,6 +32,7 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['content-available'] = self.silent if self.silent
       aps.merge!(self.other) if self.other
       aps.to_json.gsub(/\\u([\da-fA-F]{4})/) {|m| [$1].pack("H*").unpack("n*").pack("U*")}
     end
@@ -40,6 +42,7 @@ module APNS
       alert == that.alert &&
       badge == that.badge &&
       sound == that.sound &&
+      silent == that.silent &&
       other == that.other
     end
 

--- a/lib/pushmeup/version.rb
+++ b/lib/pushmeup/version.rb
@@ -1,3 +1,3 @@
 module Pushmeup
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
### What?

Apple support silent notifications using a flag on the **aps** called **content-available**. I've added support for that flag using a new parameter in the APNS notification class called **silent**
