### PR TITLE
handeled exception in case ssl object is null

### DIFF
--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -9,34 +9,34 @@ module APNS
   # openssl pkcs12 -in mycert.p12 -out client-cert.pem -nodes -clcerts
   @pem = nil # this should be the path of the pem file not the contentes
   @pass = nil
-  
+
   @persistent = false
   @mutex = Mutex.new
   @retries = 3 # TODO: check if we really need this
-  
+
   @sock = nil
   @ssl = nil
-  
+
   class << self
     attr_accessor :host, :pem, :port, :pass
   end
-  
+
   def self.start_persistence
     @persistent = true
   end
-  
+
   def self.stop_persistence
     @persistent = false
-    
+
     @ssl.close
     @sock.close
   end
-  
+
   def self.send_notification(device_token, message)
     n = APNS::Notification.new(device_token, message)
     self.send_notifications([n])
   end
-  
+
   def self.send_notifications(notifications)
     @mutex.synchronize do
       self.with_connection do
@@ -46,7 +46,7 @@ module APNS
       end
     end
   end
-  
+
   def self.feedback
     sock, ssl = self.feedback_connection
 
@@ -63,30 +63,30 @@ module APNS
 
     return apns_feedback
   end
-  
+
 protected
-  
+
   def self.with_connection
     attempts = 1
-  
-    begin      
+
+    begin
       # If no @ssl is created or if @ssl is closed we need to start it
       if @ssl.nil? || @sock.nil? || @ssl.closed? || @sock.closed?
         @sock, @ssl = self.open_connection
       end
-    
+
       yield
-    
+
     rescue StandardError, Errno::EPIPE
       raise unless attempts < @retries
-    
-      @ssl.close
+
+      @ssl.close unless @ssl.nil?
       @sock.close
-    
+
       attempts += 1
       retry
     end
-  
+
     # Only force close if not persistent
     unless @persistent
       @ssl.close
@@ -95,11 +95,11 @@ protected
       @sock = nil
     end
   end
-  
+
   def self.open_connection
     raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
     raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
-    
+
     context      = OpenSSL::SSL::SSLContext.new
     context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
     context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
@@ -110,22 +110,22 @@ protected
 
     return sock, ssl
   end
-  
+
   def self.feedback_connection
     raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
     raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
-    
+
     context      = OpenSSL::SSL::SSLContext.new
     context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
     context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
-    
+
     fhost = self.host.gsub('gateway','feedback')
-    
+
     sock         = TCPSocket.new(fhost, 2196)
     ssl          = OpenSSL::SSL::SSLSocket.new(sock, context)
     ssl.connect
 
     return sock, ssl
   end
-  
+
 end

--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -28,7 +28,7 @@ module APNS
   def self.stop_persistence
     @persistent = false
 
-    @ssl.close
+    @ssl.close unless @ssl.nil?
     @sock.close
   end
 

--- a/lib/pushmeup/apns/core.rb
+++ b/lib/pushmeup/apns/core.rb
@@ -81,7 +81,7 @@ protected
       raise unless attempts < @retries
 
       @ssl.close unless @ssl.nil?
-      @sock.close
+      @sock.close unless @sock.nil?
 
       attempts += 1
       retry


### PR DESCRIPTION
"with_connection" method raises an exception: NoMethodError: undefined method `close' for nil:NilClass

Probably, you forget to check the condition unless @ssl.nil?
so, I fixed it.
